### PR TITLE
Fix handling Guild Delete

### DIFF
--- a/src/Events.ts
+++ b/src/Events.ts
@@ -1,7 +1,7 @@
 import { Emitter, Listener } from "./util/Emitter.ts";
 
 import type { Channel } from "./structures/Channel.ts";
-import type { Guild } from "./structures/Guild.ts";
+import type { Guild, UnavailableGuild } from "./structures/Guild.ts";
 import type { GuildMember } from "./structures/GuildMember.ts";
 import type { GuildEmoji } from "./structures/GuildEmoji.ts";
 import type { ReactionCustomEmoji } from "./structures/ReactionCustomEmoji.ts";
@@ -55,7 +55,7 @@ export class Events {
    * - The client leaves or is removed from a guild.
    * - A guild becomes unavailable.
    */
-  readonly guildDelete = new Emitter<{ guild: Guild }>();
+  readonly guildDelete = new Emitter<{ guild: UnavailableGuild }>();
 
   /** Fired when a user is banned from a guild. */
   readonly guildBanAdd = new Emitter<{ guild: Guild; user: User }>();

--- a/src/network/gateway/event/handler/Guild.ts
+++ b/src/network/gateway/event/handler/Guild.ts
@@ -5,6 +5,7 @@ import {
   Guild,
   GuildCache,
   GuildHandler,
+  UnavailableGuild,
 } from "../../../../structures/Guild.ts";
 import type { User } from "../../../../structures/User.ts";
 import type { Emitter } from "../../../../util/Emitter.ts";
@@ -14,7 +15,7 @@ export interface GuildEventSubscriber
   extends RoleEventSubscriber, MemberEventSubscriber {
   guildCreate: Emitter<{ guild: Guild }>;
   guildUpdate: Emitter<{ guild: Guild }>;
-  guildDelete: Emitter<{ guild: Guild }>;
+  guildDelete: Emitter<{ guild: UnavailableGuild }>;
   guildBanAdd: Emitter<{ guild: Guild; user: User }>;
   guildBanRemove: Emitter<
     { guild: Guild; user: User }
@@ -58,7 +59,7 @@ export function handleGuildEvent(
       return;
     case "GUILD_DELETE":
       subscriber.guildDelete.emit(
-        { guild: new Guild(message.d, cache, handler) },
+        { guild: new UnavailableGuild(message.d) },
       );
       return;
     case "GUILD_BAN_ADD": {

--- a/src/structures/Guild.ts
+++ b/src/structures/Guild.ts
@@ -79,3 +79,16 @@ export class Guild {
     }
   }
 }
+
+export class UnavailableGuild {
+  readonly id: string;
+  readonly removedYouFromGuild: boolean;
+
+  constructor(data: any) {
+    if (data.unavailable === false) {
+      throw new Error(`the available guild: ${data}`);
+    }
+    this.id = data.id;
+    this.removedYouFromGuild = !("unavailable" in data);
+  }
+}


### PR DESCRIPTION
# Description
- Fix handling Guild Delete.
- Add `UnavailableGuild` class.

## Type of changes
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)
 - [ ] Documentation update (if none of the other choices apply)

## Checklist
 - [x] I have read the [CONTRIBUTING](https://github.com/fox-cat/coward/.github/CONTRIBUTING.md) document
 - [x] I have added necessary documentation (if appropriate)

## Further comments
[Officail document says](https://discord.com/developers/docs/topics/gateway#guild-delete):
> Sent when a guild becomes unavailable during a guild outage, or when the user leaves or is removed from a guild. The inner payload is an [unavailable guild](https://discord.com/developers/docs/resources/guild#unavailable-guild-object) object. If the `unavailable` field is not set, the user was removed from the guild.
