### PR TITLE
Fix the help channel name on the Discord guild

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Thank you for contributing to Coward! 🥳
 There are many ways to contribute, whether it be improving the documentation, submitting bug reports, feature requests, or writing code that can be incorporated into Coward.
 
-Don't use the issue tracker for support questions. Use the #coward-help channel on the [Discord Server](https://discord.gg/9u9Hkn7)
+Don't use the issue tracker for support questions. Use the #coward channel on the [Discord Server](https://discord.gg/9u9Hkn7)
 
 ## Reporting a Bug
 Submit a [bug report](https://github.com/fox-cat/coward/issues/new/choose). Make it clear what the issue is.


### PR DESCRIPTION
# Description
Fixes the channel name from `#coward-help` to `#coward`. Moo.

## Type of changes
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)
 - [x] Documentation update (if none of the other choices apply)

## Checklist
 - [x] I have read the [CONTRIBUTING](https://github.com/fox-cat/coward/.github/CONTRIBUTING.md) document
 - [ ] I have added necessary documentation (if appropriate)

## Further comments
Moo.